### PR TITLE
Ignore Pre-release versions of GyDi.ClashVerge

### DIFF
--- a/winget-pkgs-automation/packages/g/gydi.clashverge.json
+++ b/winget-pkgs-automation/packages/g/gydi.clashverge.json
@@ -23,7 +23,7 @@
     "ReleaseDate": "(Get-Date -Date $Response.published_at).ToString('yyyy-MM-dd')"
   },
   "AdditionalInfo": {
-    "PreRelease": true,
+    "PreRelease": false,
     "PreviousReleaseId": 63778807
   },
   "PostUpgradeScript": "$Package.AdditionalInfo.PreviousReleaseId = $Response.id",


### PR DESCRIPTION
- [x] Have you verified that a previous version of the package is already there in the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs)?
- [ ] Have you validated the JSON with the [JSON Schema](https://raw.githubusercontent.com/vedantmgoyal2009/vedantmgoyal2009/main/winget-pkgs-automation/schema.json)?
- [x] Have you verified that the values entered in the JSON are correct?
- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

https://github.com/zzzgydi/clash-verge/releases/tag/v0.0.29
There is a stable version released now.