### PR TITLE
Fix typo in WinGet Releaser Example on Docs

### DIFF
--- a/docs/docs/wr-intro.md
+++ b/docs/docs/wr-intro.md
@@ -48,7 +48,7 @@ jobs:
         with:
           identifier: Package.Identifier
           version-regex: '[0-9.]+'
-          installer-regex: '\.exe$' # only .exe files
+          installers-regex: '\.exe$' # only .exe files
           delete-previous-version: 'false' # don't forget the quotes
           token: ${{ secrets.WINGET_TOKEN }}
 ```


### PR DESCRIPTION
- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

This PR fixes a typo on the docs as it is meant to be `installers-regex` rather than `installer-regex`, as shown [here](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/b532628d32ccc462676db4ab9bcc2b196ed73563/winget-pkgs-automation/releaser-action/action.yml#L11). Copying over the incorrect example on my project caused it to fail.