### PR TITLE
fix(wpa-pkgs): microsoft.bicep - Installer Regex

### DIFF
--- a/winget-pkgs-automation/packages/m/microsoft.bicep.json
+++ b/winget-pkgs-automation/packages/m/microsoft.bicep.json
@@ -14,8 +14,8 @@
   },
   "PostResponseScript": "$UpdateCondition = $Response.prerelease -eq $PreRelease -and $Response.id -gt $PreviousReleaseId",
   "VersionRegex": "(?<=v)[0-9.]+",
-  "InstallerRegex": ".(exe|msi|msix|appx)(bundle){0,1}$",
-  "PreviousVersion": "0.4.1124",
+  "InstallerRegex": "bicep-setup.*(exe|msi|msix|appx)(bundle){0,1}$",
+  "PreviousVersion": "0.6.1.6515",
   "ManifestFields": {
     "PackageVersion": "$Response.tag_name.TrimStart('v')",
     "InstallerUrls": "$Response.assets | ForEach-Object { if ($_.name -match $InstallerRegex) { $_.browser_download_url } }",

--- a/winget-pkgs-automation/packages/m/microsoft.bicep.json
+++ b/winget-pkgs-automation/packages/m/microsoft.bicep.json
@@ -17,8 +17,8 @@
   "InstallerRegex": "bicep-setup.*(exe|msi|msix|appx)(bundle){0,1}$",
   "PreviousVersion": "0.6.1.6515",
   "ManifestFields": {
-    "PackageVersion": "$Response.tag_name.TrimStart('v')",
     "InstallerUrls": "$Response.assets | ForEach-Object { if ($_.name -match $InstallerRegex) { $_.browser_download_url } }",
+    "PackageVersion": "Read-VersionFromInstaller -Uri $_Object.InstallerUrls -Property ProductVersion",
     "ReleaseNotesUrl": "$Response.html_url",
     "ReleaseDate": "(Get-Date -Date $Response.published_at).ToString('yyyy-MM-dd')"
   },


### PR DESCRIPTION
### WinGet Automation Pull Request Checklist

- [x] Have you verified that a previous version of the package is already there in the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs)?
- [x] Have you tested the package using the [`Test-Package`](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/main/winget-pkgs-automation/tools/Test-Package.ps1) script, provided in the `tools` folder?
- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

### Extra Changes & Notes

The Microsoft.Bicep package was not updating due to an invalid regex. Now fixed.
