### PR TITLE
fix(winget-pkgs): installer-regex in plex.plexmediaserver

### DIFF
--- a/winget-pkgs-automation/packages/p/plex.plexmediaserver.json
+++ b/winget-pkgs-automation/packages/p/plex.plexmediaserver.json
@@ -10,7 +10,7 @@
     "UserAgent": ""
   },
   "PostResponseScript": "$Response = $Response.computer.Windows",
-  "VersionRegex": "[0-9.]{2,}",
+  "VersionRegex": "[0-9.]{2,}[-0-9a-f]*",
   "InstallerRegex": ".exe$",
   "PreviousVersion": "1.28.2.6151",
   "ManifestFields": {

--- a/winget-pkgs-automation/packages/p/plex.plexmediaserver.json
+++ b/winget-pkgs-automation/packages/p/plex.plexmediaserver.json
@@ -10,12 +10,12 @@
     "UserAgent": ""
   },
   "PostResponseScript": "$Response = $Response.computer.Windows",
-  "VersionRegex": "[0-9.]{2,}[-0-9a-f]*",
-  "InstallerRegex": ".exe$",
+  "VersionRegex": "[0-9.]{2,}",
+  "InstallerRegex": "x86_64\.exe$",
   "PreviousVersion": "1.28.2.6151",
   "ManifestFields": {
     "PackageVersion": "($Response.version | Select-String -Pattern $VersionRegex).Matches.Value",
-    "InstallerUrls": "$Response.releases.url"
+    "InstallerUrls": "$Response.releases.url.Where({ $_ -match $InstallerRegex })"
   },
   "AdditionalInfo": {},
   "PostUpgradeScript": "",


### PR DESCRIPTION
As 
`wget -qO - https://plex.tv/api/downloads/5.json 2>nul | jq -r .computer.Windows.version` 
returns: 
`1.30.1.6562-915986d62`

Signed-off-by: Ross Smith II <ross@smithii.com>