### PR TITLE
fix: Use archive download URL for Freeplane

### DIFF
--- a/winget-pkgs-automation/packages/f/freeplane.freeplane.json
+++ b/winget-pkgs-automation/packages/f/freeplane.freeplane.json
@@ -17,7 +17,7 @@
   "PreviousVersion": "1.11.7",
   "ManifestFields": {
     "PackageVersion": "($Response | Select-String -Pattern $VersionRegex).Matches.Value",
-    "InstallerUrls": "($Response.Replace('http://downloads.sourceforge.net/project/freeplane/', 'https://sourceforge.net/projects/freeplane/files/')) -replace '\\?.*', '/download'"
+    "InstallerUrls": "$Response -replace '^http://downloads\\.sourceforge\\.net/project/([^/]+)/([^/]+)/([^?]+)-([\\d\\.]+)\\.exe.*$', 'https://sourceforge.net/projects/$1/files/$2/archive/$4/$3-$4.exe/download'"
   },
   "AdditionalInfo": {},
   "PostUpgradeScript": "",


### PR DESCRIPTION
The currently used download URL is only temporary and valid for the latest release. It breaks with every new release. Use the archive one, which is available at the time of the release too.

### WinGet Automation Pull Request Checklist

- [x] Have you verified that a previous version of the package is already there in the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs)?
- [x] Have you tested the package using [`New-PackageJson.ps1 -TestPackage <package-identifier>`](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/main/winget-pkgs-automation/New-PackageJson.ps1) script, provided in the `winget-pkgs-automation` folder?
- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

### Extra Changes & Notes
